### PR TITLE
fix: Jenkinsfile to use npm commands instead of yarn

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
                     sh '''
                         echo "@apaleo:registry=https://npm.pkg.github.com" > .npmrc
                         echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
-                        yarn install
+                        npm install
                     '''
                 }
             }
@@ -29,7 +29,7 @@ pipeline {
         stage('Build') {
             steps {
                 sh '''
-                    yarn build
+                    npm run build
                 '''
             }
         }
@@ -47,16 +47,16 @@ pipeline {
                     sh '''
                         echo "Current package.json version:"
                         cat package.json | grep version
-                        yarn version --patch
+                        npm version patch
                         echo "New package.json version:"
                         PACKAGE_VERSION=$(node -p "require('./package.json').version")
                         echo "Version: $PACKAGE_VERSION"
                         
                         echo "Publishing package..."
-                        yarn publish
+                        npm publish --registry=https://npm.pkg.github.com
                         
                         echo "Package published successfully!"
-                        echo "Packages URL: https://github.com/apaleo/n8n-nodes-apaleo/pkgs/npm/n8n-nodes-apaleo/versions"
+                        echo "Packages URL: https://github.com/apaleo/n8n-nodes-apaleo/pkgs/npm/%40apaleo%2Fn8n-nodes-apaleo-official/versions"
                     '''
                 }
             }

--- a/README.md
+++ b/README.md
@@ -151,21 +151,39 @@ The trigger node works by subscribing to Apaleo's webhook events, allowing your 
 
 If you want to contribute or modify the nodes:
 
-1. Clone the repository
-2. Install dependencies:
+1. Clone the repository:
+   ```
+   git clone https://github.com/apaleo/n8n-nodes-apaleo.git
+   ```
+2. Navigate to the project directory:
+   ```
+   cd n8n-nodes-apaleo
+   ```
+3. Install dependencies:
    ```
    npm install
    ```
-3. Start development mode:
+4. Start development mode (watches for changes):
    ```
    npm run dev
    ```
-4. Make your changes
-5. Build the package:
+5. Format code:
+   ```
+   npm run format
+   ```
+6. Lint code:
+   ```
+   npm run lint
+   ```
+7. Fix linting issues automatically:
+   ```
+   npm run lintfix
+   ```
+8. Build the package:
    ```
    npm run build
    ```
-6. Test your changes locally
+9. Test your changes locally
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "n8n-nodes-apaleo-official",
+  "name": "@apaleo/n8n-nodes-apaleo-official",
   "version": "0.1.0",
   "description": "Apaleo API Node for n8n",
   "keywords": [


### PR DESCRIPTION
Change the package name in package.json to include the scope. Enhance the README with detailed setup instructions and additional development steps.